### PR TITLE
[queue_depth] Allow apps to boot without ENV['PORT']

### DIFF
--- a/lib/queue-metrics/queue_depth.rb
+++ b/lib/queue-metrics/queue_depth.rb
@@ -21,7 +21,7 @@ module Rack
       end
 
       def call(env)
-        return @app.call(env) unless ENV['PORT']
+        return @app.call(env) unless ENV['PORT'].to_s
         status, headers, body = @app.call(env)
         [status, headers, body]
       end

--- a/lib/queue-metrics/queue_depth.rb
+++ b/lib/queue-metrics/queue_depth.rb
@@ -21,7 +21,7 @@ module Rack
       end
 
       def call(env)
-        return @app.call(env) unless ENV['PORT'].to_s
+        return @app.call(env) unless ENV['PORT']
         status, headers, body = @app.call(env)
         [status, headers, body]
       end
@@ -29,7 +29,7 @@ module Rack
     private
 
       def getaddr
-        IPSocket.getaddress(Socket.gethostname).to_s + ':' + ENV['PORT']
+        IPSocket.getaddress(Socket.gethostname).to_s + ':' + ENV['PORT'].to_s
       rescue SocketError
         nil
       end


### PR DESCRIPTION
Fixes:

```
TypeError: no implicit conversion of nil into String
  /Users/clundquist/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rack-queue-metrics-2.0.0/lib/queue-metrics/queue_depth.rb:32:in `+'
  /Users/clundquist/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rack-queue-metrics-2.0.0/lib/queue-metrics/queue_depth.rb:32:in `getaddr'
  /Users/clundquist/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rack-queue-metrics-2.0.0/lib/queue-metrics/queue_depth.rb:12:in `initialize'
  /Users/clundquist/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.7/lib/action_dispatch/middleware/stack.rb:43:in `new'
  /Users/clundquist/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.7/lib/action_dispatch/middleware/stack.rb:43:in `build'
  /Users/clundquist/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.7/lib/action_dispatch/middleware/stack.rb:118:in `block in build'
  /Users/clundquist/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.7/lib/action_dispatch/middleware/stack.rb:118:in `each'
  /Users/clundquist/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.7/lib/action_dispatch/middleware/stack.rb:118:in `inject'
  /Users/clundquist/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/actionpack-4.2.7/lib/action_dispatch/middleware/stack.rb:118:in `build'
  /Users/clundquist/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.7/lib/rails/engine.rb:502:in `app'
  /Users/clundquist/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.7/lib/rails/application/finisher.rb:34:in `block in <module:Finisher>'
```
