### PR TITLE
[railtie] use Rails.logger by default with rails

### DIFF
--- a/lib/queue-metrics/railtie.rb
+++ b/lib/queue-metrics/railtie.rb
@@ -2,10 +2,10 @@ module Rack
   module QueueMetrics
     class RackQueueRailtie < Rails::Railtie
       initializer "rack_queue_railtie.configure_rails_initialization" do |app|
-        app.middleware.use Rack::QueueMetrics::QueueTime
+        app.middleware.use Rack::QueueMetrics::QueueTime, Rails.logger
         app.middleware.use Raindrops::Middleware
-        app.middleware.use Rack::QueueMetrics::QueueDepth
-        app.middleware.use Rack::QueueMetrics::AppTime
+        app.middleware.use Rack::QueueMetrics::QueueDepth, Rails.logger
+        app.middleware.use Rack::QueueMetrics::AppTime, Rails.logger
       end
     end
   end


### PR DESCRIPTION
Previously logging to $stdout caused undesirable output when running tests.
Since we are in a Railtie, we can pass the Rails logger which should be a reasonable default.
